### PR TITLE
Add new Blobstore Editor page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "react-datepicker": "^2.11.0",
         "react-dom": "^16.12.0",
         "react-frappe-charts": "^2.1.0",
+        "react-json-editor-ajrm": "^2.5.13",
         "react-qrcode-logo": "^2.5.0",
         "react-router-dom": "^5.1.2",
         "react-scripts": "^5.0.0",
@@ -12513,6 +12514,18 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
+    "node_modules/react-json-editor-ajrm": {
+      "version": "2.5.13",
+      "resolved": "https://registry.npmjs.org/react-json-editor-ajrm/-/react-json-editor-ajrm-2.5.13.tgz",
+      "integrity": "sha512-uYRJFzY34w7coLxeWPFZGyQpWdBKK5e8R9jBZTJ5gAFp3WuGVG2DdGZ8oJKOVJy0hqkxS9DzJIzGmmxHHQ9afA==",
+      "dependencies": {
+        "@babel/runtime": "^7.0.0-rc.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.2.0",
+        "react-dom": ">=16.2.0"
+      }
     },
     "node_modules/react-onclickoutside": {
       "version": "6.12.1",
@@ -25085,6 +25098,14 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
+    "react-json-editor-ajrm": {
+      "version": "2.5.13",
+      "resolved": "https://registry.npmjs.org/react-json-editor-ajrm/-/react-json-editor-ajrm-2.5.13.tgz",
+      "integrity": "sha512-uYRJFzY34w7coLxeWPFZGyQpWdBKK5e8R9jBZTJ5gAFp3WuGVG2DdGZ8oJKOVJy0hqkxS9DzJIzGmmxHHQ9afA==",
+      "requires": {
+        "@babel/runtime": "^7.0.0-rc.0"
+      }
     },
     "react-onclickoutside": {
       "version": "6.12.1",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "react-datepicker": "^2.11.0",
     "react-dom": "^16.12.0",
     "react-frappe-charts": "^2.1.0",
+    "react-json-editor-ajrm": "^2.5.13",
     "react-qrcode-logo": "^2.5.0",
     "react-router-dom": "^5.1.2",
     "react-scripts": "^5.0.0",

--- a/src/App.js
+++ b/src/App.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { BrowserRouter, Switch, Route, NavLink } from 'react-router-dom';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faUsers, faBell, faCalendar, faBars, faCalculator } from '@fortawesome/free-solid-svg-icons';
+import { faUsers, faBell, faCalendar, faBars, faCalculator, faSplotch } from '@fortawesome/free-solid-svg-icons';
 
 import './App.scss';
 import logo from './assets/logo.svg';
@@ -12,12 +12,14 @@ import Events from './scenes/Events';
 import Notifications from './scenes/Notifications';
 import Statistics from 'scenes/Statistics';
 import Token from 'scenes/Token';
+import Blobstore from 'scenes/Blobstore';
 
 const routes = [
   { path: '/', name: "Statistics", icon: faCalculator },
   { path: '/users', name: "Users", icon: faUsers },
   { path: '/notifications', name: "Notifications", icon: faBell },
   { path: '/events', name: "Events", icon: faCalendar },
+  { path: '/blobstore', name: "Blobstore", icon: faSplotch },
 ];
 
 class App extends React.Component {
@@ -81,6 +83,10 @@ class App extends React.Component {
   
             <AuthenticatedRoute path="/notifications">
               <Notifications/>
+            </AuthenticatedRoute>
+
+            <AuthenticatedRoute path="/blobstore">
+              <Blobstore />
             </AuthenticatedRoute>
 
             <AuthenticatedRoute path="/token" provider="github">

--- a/src/components/FormPopup/index.jsx
+++ b/src/components/FormPopup/index.jsx
@@ -63,12 +63,19 @@ const ModalPopup = ({ children }) => {
 
 const FormPopup = ({ form, children, onSubmit, onCancel, overrideShow, ...props }) => {
   const [show, setShow] = useState(false);
+  const popupContent = useRef(null);
 
   useEffect(() => {
     if (overrideShow !== undefined) {
       setShow(overrideShow);
     }
   }, [overrideShow]);
+
+  useEffect(() => {
+    if (show && popupContent.current) {
+      popupContent.current.focus();
+    }
+  }, [show]);
 
   // only set show if overrideShow isn't specified
   const maybeSetShow = value => {
@@ -92,6 +99,12 @@ const FormPopup = ({ form, children, onSubmit, onCancel, overrideShow, ...props 
     maybeSetShow(false);
   };
 
+  const handleKeyUp = e => {
+    if (e.key === 'Escape') {
+      cancel();
+    }
+  };
+
   const CustomForm = form;
   const childrenWithClickListener = children && React.cloneElement(children, { onClick: () => maybeSetShow(true) });
   return (
@@ -100,8 +113,8 @@ const FormPopup = ({ form, children, onSubmit, onCancel, overrideShow, ...props 
 
       {show && (
         <ModalPopup>
-          <div className="form-popup" onClick={cancel}>
-            <div className="popup-content" onClick={e => e.stopPropagation()}>
+          <div className="form-popup" onClick={cancel} onKeyUp={handleKeyUp}>
+            <div className="popup-content" onClick={e => e.stopPropagation()} tabIndex={-1} ref={popupContent}>
               <CustomForm onSubmit={submit} onCancel={cancel} {...props} />
             </div>
           </div>

--- a/src/components/FormPopup/style.scss
+++ b/src/components/FormPopup/style.scss
@@ -17,5 +17,6 @@
     max-width: calc(100% - 20px);
     max-height: calc(100% - 20px);
     overflow: auto;
+    outline: none;
   }
 }

--- a/src/constants.scss
+++ b/src/constants.scss
@@ -67,6 +67,7 @@ $desktop-min-width: 1024px;
   padding: 7px 20px;
   border-radius: 5px;
   border: $color 2px solid;
+  font-family: inherit;
   font-weight: bold;
   color: $color;
   font-size: .95em;
@@ -88,4 +89,17 @@ $desktop-min-width: 1024px;
     color: hsl(0,0%,70%);
     cursor: not-allowed;
   }
+}
+
+// Apply on <button> to remove all the button styles and make it look like a div
+@mixin div-button() {
+  display: block;
+  background: none;
+  border: none;
+  outline: none;
+  font-family: inherit;
+  font-size: 1em;
+  text-align: left;
+
+  // calling style should set something for &:hover and &:focus to indicate such
 }

--- a/src/constants.scss
+++ b/src/constants.scss
@@ -2,11 +2,14 @@ $primary-color: #505F85;
 $secondary-color: #5E997A;
 $red: #cc0000;
 
+$primary-color-light: lighten($primary-color, 40%);
+$secondary-color-light: lighten($secondary-color, 40%);
+
 :export { // allows you to import these variables from javascript
   primaryColor: $primary-color;
-  primaryColorLight: lighten($primary-color, 40%);
+  primaryColorLight: $primary-color-light;
   secondaryColor: $secondary-color;
-  secondaryColorLight: lighten($secondary-color, 40%);
+  secondaryColorLight: $secondary-color-light;
 }
 
 $tablet-min-width: 768px;
@@ -69,9 +72,20 @@ $desktop-min-width: 1024px;
   font-size: .95em;
   cursor: pointer;
   transition: color .2s, background-color .2s;
+  
+  &:focus {
+    background-color: $primary-color-light;
+  }
 
-  &:hover, &:focus {
+  &:hover {
     background-color: $color;
     color: white;
+  }
+
+  &:disabled {
+    background-color: initial;
+    border-color: hsl(0,0%,70%);
+    color: hsl(0,0%,70%);
+    cursor: not-allowed;
   }
 }

--- a/src/scenes/Blobstore/index.jsx
+++ b/src/scenes/Blobstore/index.jsx
@@ -1,0 +1,104 @@
+import { useReducer, useState } from 'react';
+import JSONInput from 'react-json-editor-ajrm';
+import locale from 'react-json-editor-ajrm/locale/en';
+import { createBlob, getBlob, updateBlob } from 'util/api';
+
+import './style.scss';
+
+const initialPlaceholder = { text: 'placeholder' };
+const defaultGetButtonText = 'Get Blob';
+const defaultUpdateButtonText = 'Set Blob';
+const resetTextTimeout = 2000; // the text of the buttons is used to indicate status, and we reset it to default after a short delay
+
+const getFailedResponseData = async (res) => res.json ? await res.json() : null;
+const createAPIErrorMessage = async (message, failedRes) => {
+  const responseData = await getFailedResponseData(failedRes);
+  if (responseData) {
+    return `${message}, error: ${JSON.stringify(responseData)}`;
+  }
+  return message;
+}
+
+const Blobstore = () => {
+  const [blobId, setBlobId] = useState('');
+  const [initialBlobValue, setInitialBlobValue] = useState(initialPlaceholder);
+  const [blobValue, setBlobValue] = useState(initialPlaceholder);
+  const [getButtonText, setGetButtonText] = useState(defaultGetButtonText);
+  const [updateButtonText, setUpdateButtonText] = useState(defaultUpdateButtonText);
+  
+  // calling forceReset() will cause the JSONInput to re-render with the initial value
+  // (this works by incrementing the key passed to JSONInput when forceReset() is called)
+  const [jsonInputKey, forceResetJSONInput] = useReducer(x => x + 1, 0);
+
+  const getBlobData = () => {
+    if (!blobId) {
+      alert("Please specify a blob ID");
+      setInitialBlobValue(initialPlaceholder);
+    } else {
+      setGetButtonText("Loading...");
+      getBlob(blobId)
+        .then(blob => {
+          setInitialBlobValue(blob.data);
+          forceResetJSONInput();
+          setGetButtonText('Success!');
+        })
+        .catch(async (res) => {
+          setGetButtonText('Error!');
+          alert(await createAPIErrorMessage('Failed to get blob', res));
+        })
+        .finally(() => {
+          setTimeout(() => setGetButtonText(defaultGetButtonText), resetTextTimeout)
+        });
+    }
+  };
+
+  const setBlobData = async () => {
+    if (!blobId) { 
+      alert("Please specify a blob ID");
+    } else {
+      setUpdateButtonText("Loading...");
+
+      // First we see if the blob already exists in order to determine whether to create or update
+      const doesBlobExist = await getBlob(blobId).then(() => true).catch(() => false);
+      try {
+        if (doesBlobExist) {
+          await updateBlob(blobId, blobValue);
+        } else {
+          await createBlob(blobId, blobValue);
+        }
+        setUpdateButtonText("Success!");
+      } catch (res) {
+        setUpdateButtonText("Error!");
+        alert(await createAPIErrorMessage('Failed to set blob', res));
+      } finally {
+        setTimeout(() => setUpdateButtonText(defaultUpdateButtonText), resetTextTimeout);
+      }
+    }
+  };
+
+  return (
+    <div className="blobstore-page">
+      <div className='blobstore-buttons'>
+        <input className='blob-id-input' type="text" placeholder="Blob ID" value={blobId} onChange={e => setBlobId(e.target.value)} />
+        <button className='get-blob-button' onClick={getBlobData} disabled={getButtonText !== defaultGetButtonText}>{getButtonText}</button>
+        <button className='update-blob-button' onClick={setBlobData} disabled={updateButtonText !== defaultUpdateButtonText}>{updateButtonText}</button>
+      </div>
+
+      <JSONInput
+        id='blobstore-json'
+        placeholder={initialBlobValue}
+        onChange={({ jsObject }) => setBlobValue(jsObject)}
+        locale={locale}
+        height={`${window.innerHeight*.8 - 50}px`}
+        style={{
+          outerBox: { width: 'auto' },
+          container: { width: 'auto', borderRadius: '7px' },
+          body: { fontSize: '14px' },
+        }}
+        key={jsonInputKey.toString()}
+      />
+    </div>
+  )
+}
+
+export default Blobstore;

--- a/src/scenes/Blobstore/style.scss
+++ b/src/scenes/Blobstore/style.scss
@@ -1,0 +1,26 @@
+@import 'constants.scss';
+
+.blobstore-page {
+  flex: 1;
+  margin-top: 10vh;
+  padding-right: 25px;
+  box-sizing: border-box;
+
+  .blobstore-buttons {
+    height: 40px;
+    margin-bottom: 10px;
+    display: flex;
+
+    input {
+      @include form-field;
+      width: auto;
+      flex: 1;
+      margin: 0;
+    }
+    
+    button {
+      @include button;
+      margin-left: 10px;
+    }
+  }
+}

--- a/src/scenes/Events/EventCard/index.jsx
+++ b/src/scenes/Events/EventCard/index.jsx
@@ -31,16 +31,16 @@ const EventCard = ({ event, canEdit, onClick, isAddButton }) => {
   if (isAddButton) {
     return (
       <div className="event-card-container">
-        <div className={clsx('event-card', 'add-button', 'clickable')} onClick={onClick}>
+        <button className={clsx('event-card', 'add-button', 'clickable')} onClick={onClick}>
           <FontAwesomeIcon className="add-event-icon" icon={faPlus} />
-        </div>
+        </button>
       </div>
     );
   }
 
   return (
     <div className="event-card-container">
-      <div
+      <button
         className={clsx('event-card', canEdit && 'clickable')}
         onClick={e => canEdit && onClick(e)}
       >
@@ -67,13 +67,13 @@ const EventCard = ({ event, canEdit, onClick, isAddButton }) => {
             {event.eventType}
           </div>
         </div>
-      </div>
-
-      <button className="event-code-button">
-        <FormPopup form={EventCodeForm} event={event}>
-          <FontAwesomeIcon icon={faKey} fixedWidth />
-        </FormPopup>
       </button>
+
+      <FormPopup form={EventCodeForm} event={event}>
+        <button className="event-code-button">
+          <FontAwesomeIcon icon={faKey} fixedWidth />
+        </button>
+      </FormPopup>
     </div>
   )
 };

--- a/src/scenes/Events/EventCard/style.scss
+++ b/src/scenes/Events/EventCard/style.scss
@@ -5,6 +5,8 @@
   margin: 20px;
 
   .event-card {
+    @include div-button;
+    width: 100%;
     border: $primary-color 1.5px solid;
     border-radius: 7px;
     padding: 15px;
@@ -13,7 +15,7 @@
   
     &.clickable {
       cursor: pointer;
-      &:hover {
+      &:hover, &:focus {
         background-color: #f0f0f0;
       }
     }
@@ -66,6 +68,8 @@
   }
 
   .event-code-button {
+    @include div-button;
+
     cursor: pointer;
     position: absolute;
     bottom: 6px;
@@ -75,13 +79,14 @@
     color: $secondary-color;
     background-color: white;
     
-    outline: none;
     padding: 4px;
     border: 1px solid $primary-color;
     border-radius: 50px;
+    transition: border-width .1s, box-shadow .1s;
     
-    &:hover {
+    &:hover, &:focus {
       box-shadow: 0px 1px 4px rgba(0, 0, 0, 0.25);
+      border-width: 2px;
     }
   }
 }

--- a/src/scenes/Events/EventCodeForm/style.scss
+++ b/src/scenes/Events/EventCodeForm/style.scss
@@ -23,7 +23,8 @@
 
   .qr-container {
     display: flex;
-    align-items: flex-start;
+    flex-direction: column;
+    align-items: center;
     justify-content: space-between;
     margin: 5px 0;
 

--- a/src/scenes/Events/EventEditPopup/index.jsx
+++ b/src/scenes/Events/EventEditPopup/index.jsx
@@ -49,6 +49,12 @@ export default class EventEditPopup extends React.Component {
     }
   }
 
+  handleKeyUp(e) {
+    if (e.key === 'Escape') {
+      this.props.onDismiss();
+    }
+  };
+
   isNewEvent() {
     // if the id property of the event prop does not exist, it means we're creating a new event
     return !this.props.event.id;
@@ -56,7 +62,7 @@ export default class EventEditPopup extends React.Component {
 
   render() {
     return (
-      <div className="event-edit-popup">
+      <div className="event-edit-popup" onKeyUp={e => this.handleKeyUp(e)}>
         <div className="popup-background" onClick={() => this.props.onDismiss()}/>
 
         <div className="popup-container">
@@ -64,7 +70,7 @@ export default class EventEditPopup extends React.Component {
           <Formik initialValues={this.state.eventValues} onSubmit={values => this.submit(values)}>
             {() => (
               <Form className="form">
-                <Field className="form-field" name="name" placeholder="Event Name"/>
+                <Field className="form-field" name="name" placeholder="Event Name" autoFocus/>
                 <Field component={DateInput} name="startTime" label="Start:"/>
                 <Field component={DateInput} name="endTime" label="End:"/>
                 <Field className="form-field" name="description" as="textarea" rows="5" placeholder="Description"/>

--- a/src/scenes/Users/DecisionButtons/style.scss
+++ b/src/scenes/Users/DecisionButtons/style.scss
@@ -30,12 +30,5 @@
     &.accept {
       margin-right: 20px;
     }
-
-    &:disabled {
-      color: #999999;
-      border-color: #999999;
-      background-color: white;
-      cursor: not-allowed;
-    }
   }
 }

--- a/src/util/api.js
+++ b/src/util/api.js
@@ -12,7 +12,7 @@ function request(method, endpoint, body) {
     if (res.ok) {
       return res.json();
     }
-    throw Error(res);
+    throw res;
   });
 }
 
@@ -149,4 +149,16 @@ export function getEventCode(eventId) {
 
 export function setEventCode(eventId, code, expiration) {
   return request('PUT', `/event/code/${eventId}/`, { id: eventId, code, expiration });
+}
+
+export function getBlob(blobId) {
+  return request('GET', `/upload/blobstore/${blobId}/`);
+}
+
+export function updateBlob(blobId, data) {
+  return request('PUT', `/upload/blobstore/`, { id: blobId, data });
+}
+
+export function createBlob(blobId, data) {
+  return request('POST', `/upload/blobstore/`, { id: blobId, data });
 }


### PR DESCRIPTION
- Adds a new page that lets the user view, update, and create blobstore entries
  - The API currently doesn't include an endpoint that returns all of the blobstore entry ids, so the user will need to manually enter the id for the blob they want to view/update
- Includes a JSON editor that pretty prints, highlights, and error checks user entered data
- Also made a bunch of accessibility related changes, mostly related to making sure that the focus is correctly handled, i.e.
  - the user should be able to tab through all clickable items
  - any popups should move the focus to that popup when it's displayed
  - etc.