### PR TITLE
Convert to new notification format

### DIFF
--- a/src/scenes/Notifications/index.jsx
+++ b/src/scenes/Notifications/index.jsx
@@ -29,6 +29,7 @@ const topicOptions = [
     { label: "Event", value: "Event" },
     { label: "Staff Shift", value: "StaffShift" },
     { label: "Food Wave", value: "FoodWave" },
+    { label: "Users", value: "UserIds" },
 ];
 
 const roles = [
@@ -126,6 +127,7 @@ export default class Notifications extends React.Component {
             notification.topic === "Event" && (notificationToSend.eventId = notification.eventId);
             notification.topic === "StaffShift" && (notificationToSend.staffShift = notification.staffShift);
             notification.topic === "FoodWave" && (notificationToSend.foodWave = notification.foodWave);
+            notification.topic === "UserIds" && (notificationToSend.userIds = notification.userIds.split(",").map(s => s.trim()));
 
             this.setState({
                 sendProcessing: true,
@@ -210,6 +212,14 @@ export default class Notifications extends React.Component {
                                                 className="select"
                                                 placeholder="Select Food Wave"
                                                 options={foodWaves}
+                                            />
+                                        )}
+
+                                        {props.values.topic === "UserIds" && (
+                                            <Field
+                                                name="userIds"
+                                                className="form-field"
+                                                placeholder="Enter User Ids (comma separated)"
                                             />
                                         )}
 

--- a/src/util/api.js
+++ b/src/util/api.js
@@ -125,21 +125,8 @@ export function getNotifications() {
 }
 
 export async function sendNotification(notification) {
-  const batchResponse = await request(
-    'POST', '/notification/batch', notification
-  );
-
-  const batches = batchResponse.batches;
-
-  await Promise.all(
-    batches.map((batchId) =>
-      request('POST',
-        '/notification/send',
-        {
-          batchId,
-        }
-      )
-    )
+  return await request(
+    'POST', '/notification/send/', notification
   );
 }
 


### PR DESCRIPTION
This converts the admin site to use the new notification endpoint format, which supports sending a notification to a specific set of users and removes the batches requirement.